### PR TITLE
Reset session on Haka login to prevent session fixation

### DIFF
--- a/app/controllers/haka_auth_controller.rb
+++ b/app/controllers/haka_auth_controller.rb
@@ -13,6 +13,9 @@ class HakaAuthController < ApplicationController
     raise NotImplementedError, "Fake authentication is not enabled" unless Vaalit::Config.fake_auth_enabled?
 
     student_number_multiattr = ["#{Vaalit::Haka::HAKA_STUDENT_NUMBER_KEY}:#{params[:fake_authentication][:student_number]}"]
+
+    # Discard the pre-login session to prevent session fixation.
+    reset_session
     session[:haka_attrs] = {
       "student_number": student_number_multiattr,
       "email": "fake.auth@example.com",
@@ -60,6 +63,9 @@ class HakaAuthController < ApplicationController
     end
 
     Rails.logger.debug "Reponse attributes: #{response.attributes.inspect}"
+
+    # Discard the pre-login session to prevent session fixation.
+    reset_session
     session[:haka_attrs] = {
       "student_number" => response.attributes.multi(Vaalit::Haka::HAKA_STUDENT_NUMBER_FIELD),
       "email" => response.attributes.single(Vaalit::Haka::HAKA_EMAIL_FIELD),

--- a/spec/controllers/haka_auth_controller_spec.rb
+++ b/spec/controllers/haka_auth_controller_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+# Regression specs for session fixation: an attacker who plants a session
+# cookie before the victim logs in must not inherit the authenticated session.
+describe HakaAuthController, type: :controller do
+  describe "#create_fake_authentication" do
+    it "resets the pre-login session" do
+      session[:planted_by_attacker] = "anything"
+
+      post :create_fake_authentication,
+        params: { fake_authentication: { student_number: "012345678" } }
+
+      expect(session[:planted_by_attacker]).to be_nil
+      expect(session[:haka_attrs]).to be_present
+      expect(response).to redirect_to(registrations_root_path)
+    end
+  end
+
+  describe "#consume" do
+    it "resets the pre-login session" do
+      student_number_urn = "#{Vaalit::Haka::HAKA_STUDENT_NUMBER_KEY}:012345678"
+      attributes = double("Attributes", multi: [student_number_urn], single: "value")
+      saml_response = double("Response", is_valid?: true, attributes: attributes)
+      allow(OneLogin::RubySaml::Response).to receive(:new).and_return(saml_response)
+
+      session[:planted_by_attacker] = "anything"
+
+      post :consume, params: { SAMLResponse: "dummy" }
+
+      expect(session[:planted_by_attacker]).to be_nil
+      expect(session[:haka_attrs]).to be_present
+      expect(response).to redirect_to(registrations_root_path)
+    end
+  end
+end


### PR DESCRIPTION
Plan item **1.1** (security, highest priority).

`HakaAuthController#consume` and `#create_fake_authentication` wrote `session[:haka_attrs]` into the pre-existing session. An attacker who plants a session cookie before the victim logs in (e.g. via a shared computer or subdomain cookie injection) would inherit the authenticated session.

**Fix:** `reset_session` immediately before setting `session[:haka_attrs]` in both actions. Nothing else in the session needs to survive login.

Regression specs (controller-level, both actions): a value planted in the pre-login session is gone after login. Verified to fail without the fix (2/2).

Base branch is `test-infrastructure` (#63) — merge that first; GitHub retargets this PR automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)