### PR TITLE
Guard mass email against double send, escape preview XSS

### DIFF
--- a/app/admin/emails.rb
+++ b/app/admin/emails.rb
@@ -23,9 +23,17 @@ ActiveAdmin.register Email do
 
   show :title => :subject do
     attributes_table :subject do
-      row("content") { raw "<pre>#{email.content}</pre>" }
+      row("content") { pre email.content }
       row("Lähetetty") { friendly_datetime(email.enqueued_at) }
-      row("Lähetys") { button_to 'Lähetä sähköposti ehdokkaille', send_mail_admin_email_path, method: :post }
+      row("Lähetys") do
+        if email.enqueued_at?
+          "Sähköposti on jo lähetetty."
+        else
+          button_to 'Lähetä sähköposti ehdokkaille', send_mail_admin_email_path,
+            method: :post,
+            data: { confirm: "Lähetetäänkö sähköposti kaikille ehdokkaille?" }
+        end
+      end
     end
   end
 
@@ -39,9 +47,12 @@ ActiveAdmin.register Email do
 
   member_action :send_mail, :method => :post do
     message = Email.find(params[:id])
-    message.enqueue!
 
-    redirect_to admin_emails_path, :notice => 'Sähköpostin lähetys ehdokkaille on nyt ajastettu. Järjestelmä lähettää viestejä itsekseen taustalla. Etusivulla on linkki sähköpostien lähetystietoihin.'
+    if message.enqueue!
+      redirect_to admin_emails_path, :notice => 'Sähköpostin lähetys ehdokkaille on nyt ajastettu. Järjestelmä lähettää viestejä itsekseen taustalla. Etusivulla on linkki sähköpostien lähetystietoihin.'
+    else
+      redirect_to admin_email_path(message), :alert => 'Sähköposti on jo lähetetty, eikä sitä lähetetä uudelleen.'
+    end
   end
 
 end

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -14,7 +14,11 @@ class Email < ActiveRecord::Base
     authorizable_ransackable_associations
   end
 
+  # Enqueues a send-to-all-candidates job once. Returns false if the email
+  # has already been sent.
   def enqueue!
+    return false if enqueued_at?
+
     Delayed::Job::enqueue(EnqueueCandidateEmails.new(self))
     mark_enqueued!
   end

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe Email do
+  describe "#enqueue!" do
+    it "enqueues a delayed job and stamps enqueued_at" do
+      email = Email.create!(subject: "Tiedote", content: "Sisältö")
+
+      expect { email.enqueue! }.to change { Delayed::Job.count }.by(1)
+      expect(email.enqueued_at).to be_present
+    end
+
+    it "refuses to enqueue an already sent email again" do
+      email = Email.create!(subject: "Tiedote", content: "Sisältö")
+      email.enqueue!
+
+      expect {
+        expect(email.enqueue!).to eq false
+      }.not_to change { Delayed::Job.count }
+    end
+  end
+end

--- a/spec/requests/admin_emails_spec.rb
+++ b/spec/requests/admin_emails_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe "Admin emails" do
+  before do
+    sign_in create(:admin_user)
+  end
+
+  it "escapes email content in the preview" do
+    email = Email.create!(subject: "Tiedote", content: "<script>alert('xss')</script>")
+
+    get admin_email_path(email)
+
+    expect(response.body).not_to include("<script>alert")
+    expect(response.body).to include("&lt;script&gt;")
+  end
+
+  it "does not send the same email twice" do
+    email = Email.create!(subject: "Tiedote", content: "Sisältö")
+
+    post send_mail_admin_email_path(email)
+    expect(Delayed::Job.count).to eq 1
+
+    expect {
+      post send_mail_admin_email_path(email)
+    }.not_to change { Delayed::Job.count }
+    expect(flash[:alert]).to be_present
+  end
+end


### PR DESCRIPTION
Plan items **1.3** and **1.7** (security).

**1.3 — double-send guard.** `Email#enqueue!` enqueued the send-to-all-candidates job and only afterwards stamped `enqueued_at`; nothing ever checked it, and the send button stayed visible after sending. The guard is in the model (root cause — covers every caller), the button is hidden on the show page once sent, and sending now asks for confirmation. The member action reports 'already sent' instead of a false success notice.

**1.7 — stored XSS.** The admin email preview rendered `raw "<pre>#{email.content}</pre>"`. Arbre's `pre` element escapes the content automatically.

Regression specs: model-level double-send guard, request-level double-send through the admin endpoint, and escaped `<script>` in the preview. 3/4 fail without the fixes (the fourth is the happy-path baseline).

Base: `test-infrastructure` (#63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)