### PR TITLE
Require POST for alliance freeze action (CSRF)

### DIFF
--- a/app/admin/electoral_alliances.rb
+++ b/app/admin/electoral_alliances.rb
@@ -108,10 +108,10 @@ ActiveAdmin.register ElectoralAlliance do
 
   action_item :mark_alliance_frozen, :only => :show do
     ea = ElectoralAlliance.find_by_id(params[:id])
-    link_to 'Merkitse vaaliliitto valmiiksi!', done_admin_electoral_alliance_path if can? :update, electoral_alliance and !ea.secretarial_freeze
+    link_to 'Merkitse vaaliliitto valmiiksi!', done_admin_electoral_alliance_path, method: :post if can? :update, electoral_alliance and !ea.secretarial_freeze
   end
 
-  member_action :done do
+  member_action :done, :method => :post do
     if ElectoralAlliance.find_by_id(params[:id]).freeze!
       redirect_to admin_electoral_alliances_path, :notice => "Vaaliliitto on merkitty valmiiksi!"
     else

--- a/spec/requests/admin_electoral_alliances_spec.rb
+++ b/spec/requests/admin_electoral_alliances_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe "Admin electoral alliance freeze (done)" do
+  let(:alliance) do
+    create(:electoral_alliance, secretarial_freeze: false, expected_candidate_count: 1)
+  end
+
+  before do
+    create(:candidate, electoral_alliance: alliance, alliance_accepted: true)
+    sign_in create(:admin_user)
+  end
+
+  it "freezes the alliance via POST" do
+    post done_admin_electoral_alliance_path(alliance)
+
+    expect(response).to redirect_to(admin_electoral_alliances_path)
+    expect(alliance.reload.secretarial_freeze).to eq true
+  end
+
+  it "does not respond to GET (CSRF protection)" do
+    get done_admin_electoral_alliance_path(alliance)
+
+    expect(response).to have_http_status(:not_found)
+    expect(alliance.reload.secretarial_freeze).to eq false
+  end
+end


### PR DESCRIPTION
Plan item **1.2** (security; the `done` half — logout GETs stay as-is per the review decision).

`member_action :done` (freeze alliance) defaulted to GET and was triggered by a plain `link_to`, making it CSRF-able. Now `method: :post` on both the member action and the link, the exact pattern already used for `cancel_admin_candidate_path`.

Regression specs: POST freezes the alliance; GET returns 404 and does not freeze. Both fail without the fix.

Base: `test-infrastructure` (#63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)