### PR TITLE
Authorize manage pages with an explicit ability

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -8,70 +8,72 @@ ActiveAdmin.register_page "Dashboard" do
 
     columns do
       column max_width: "300px" do
-        panel "Ylläpidon toiminnot" do
-          section 'Ehdokastiedot' do
-            ul do
-              li link_to 'Yksinkertaistettu lista ehdokastiedoista', manage_candidates_path
-              li link_to 'Muutokset ehdokasasettelun jälkeen', manage_candidate_attribute_changes_path
-              li link_to 'Vaaralliset toiminnot', manage_danger_zone_path
-            end
-          end
-
-          # Please note that in order to have control over the CSV export, you must use a custom controller.
-          # See eg. manage/candidates_controller for Candidate CSV export.
-          section "Tiedot Exceliin (CSV Export)" do
-            ul do
-              li link_to(
-                "Ehdokkaat (UTF-8)",
-                manage_candidates_path(format: :csv),
-                download: "candidates.csv"
-              )
-              li link_to(
-                "Ehdokkaat (ISO-Latin)",
-                manage_candidates_path(format: :csv, isolatin: true),
-                download: "candidates.isolatin.csv"
-              )
-              li link_to(
-                "Ehdokkaat (ei osoitetietoja, UTF-8)",
-                reduced_manage_candidates_path(format: :csv),
-                download: "candidates-reduced.csv"
-              )
-              li link_to(
-                "Vaaliliitot (UTF-8)",
-                manage_electoral_alliances_path(format: :csv),
-                download: "alliances.csv"
-              )
-              li link_to(
-                "Vaaliliitot (ISO-Latin)",
-                manage_electoral_alliances_path(format: :csv, isolatin: true),
-                download: "alliances.isolatin.csv"
-              )
-              li link_to(
-                "Vaalirenkaat (UTF-8)",
-                manage_electoral_coalitions_path(format: :csv),
-                download: "coalitions.csv"
-              )
-              li link_to(
-                "Vaalirenkaat (ISO-Latin)",
-                manage_electoral_coalitions_path(format: :csv, isolatin: true),
-                download: "coalitions.isolatin.csv"
-              )
-            end
-            section "Ohjeet CSV-tiedoston tuomiseksi Exceliin" do
-              ol do
-                li "Avaa CSV-tiedosto Exceliin."
-                li "Valitse ja mustaa koko sarake 'A'."
-                li "Valitse: Tiedot > Teksti sarakkeisiin"
-                li "Valitse: Tiedostolaji: Erotettu > Seuraava."
-                li "Valitse: Erottimet: Pilkku > Valmis."
-                li "HUOM! Google Docsille UTF-8, MS Excelille ISO-Latin."
+        if can? :access, :manage_pages
+          panel "Ylläpidon toiminnot" do
+            section 'Ehdokastiedot' do
+              ul do
+                li link_to 'Yksinkertaistettu lista ehdokastiedoista', manage_candidates_path
+                li link_to 'Muutokset ehdokasasettelun jälkeen', manage_candidate_attribute_changes_path
+                li link_to 'Vaaralliset toiminnot', manage_danger_zone_path
               end
             end
-          end
 
-          section 'Muiden sidosryhmien sisäänkirjautuminen' do
-            ul do
-              li link_to 'Edustaja (liiton 1. edustaja)', advocate_index_path
+            # Please note that in order to have control over the CSV export, you must use a custom controller.
+            # See eg. manage/candidates_controller for Candidate CSV export.
+            section "Tiedot Exceliin (CSV Export)" do
+              ul do
+                li link_to(
+                  "Ehdokkaat (UTF-8)",
+                  manage_candidates_path(format: :csv),
+                  download: "candidates.csv"
+                )
+                li link_to(
+                  "Ehdokkaat (ISO-Latin)",
+                  manage_candidates_path(format: :csv, isolatin: true),
+                  download: "candidates.isolatin.csv"
+                )
+                li link_to(
+                  "Ehdokkaat (ei osoitetietoja, UTF-8)",
+                  reduced_manage_candidates_path(format: :csv),
+                  download: "candidates-reduced.csv"
+                )
+                li link_to(
+                  "Vaaliliitot (UTF-8)",
+                  manage_electoral_alliances_path(format: :csv),
+                  download: "alliances.csv"
+                )
+                li link_to(
+                  "Vaaliliitot (ISO-Latin)",
+                  manage_electoral_alliances_path(format: :csv, isolatin: true),
+                  download: "alliances.isolatin.csv"
+                )
+                li link_to(
+                  "Vaalirenkaat (UTF-8)",
+                  manage_electoral_coalitions_path(format: :csv),
+                  download: "coalitions.csv"
+                )
+                li link_to(
+                  "Vaalirenkaat (ISO-Latin)",
+                  manage_electoral_coalitions_path(format: :csv, isolatin: true),
+                  download: "coalitions.isolatin.csv"
+                )
+              end
+              section "Ohjeet CSV-tiedoston tuomiseksi Exceliin" do
+                ol do
+                  li "Avaa CSV-tiedosto Exceliin."
+                  li "Valitse ja mustaa koko sarake 'A'."
+                  li "Valitse: Tiedot > Teksti sarakkeisiin"
+                  li "Valitse: Tiedostolaji: Erotettu > Seuraava."
+                  li "Valitse: Erottimet: Pilkku > Valmis."
+                  li "HUOM! Google Docsille UTF-8, MS Excelille ISO-Latin."
+                end
+              end
+            end
+
+            section 'Muiden sidosryhmien sisäänkirjautuminen' do
+              ul do
+                li link_to 'Edustaja (liiton 1. edustaja)', advocate_index_path
+              end
             end
           end
         end

--- a/app/controllers/manage/candidate_attribute_changes_controller.rb
+++ b/app/controllers/manage/candidate_attribute_changes_controller.rb
@@ -4,9 +4,4 @@ class Manage::CandidateAttributeChangesController < ManageController
     @changes = CandidateAttributeChange.by_creation
   end
 
-  protected
-
-  def authorize_this!
-    authorize! :candidate_attribute_changes, @current_admin_user
-  end
 end

--- a/app/controllers/manage/candidates_controller.rb
+++ b/app/controllers/manage/candidates_controller.rb
@@ -16,9 +16,4 @@ class Manage::CandidatesController < ManageController
     end
   end
 
-  protected
-
-  def authorize_this!
-    authorize! :candidates, @current_admin_user
-  end
 end

--- a/app/controllers/manage/configurations_controller.rb
+++ b/app/controllers/manage/configurations_controller.rb
@@ -13,10 +13,6 @@ class Manage::ConfigurationsController < ManageController
 
   protected
 
-  def authorize_this!
-    authorize! :configurations, @current_admin_user
-  end
-
   def find_configuration
     @configuration = GlobalConfiguration.first
   end

--- a/app/controllers/manage/danger_zones_controller.rb
+++ b/app/controllers/manage/danger_zones_controller.rb
@@ -15,9 +15,4 @@ class Manage::DangerZonesController < ManageController
     end
   end
 
-  protected
-
-  def authorize_this!
-    authorize! :tools, @current_admin_user
-  end
 end

--- a/app/controllers/manage/electoral_alliances_controller.rb
+++ b/app/controllers/manage/electoral_alliances_controller.rb
@@ -9,9 +9,4 @@ class Manage::ElectoralAlliancesController < ManageController
     end
   end
 
-  protected
-
-  def authorize_this!
-    authorize! :alliances, @current_admin_user
-  end
 end

--- a/app/controllers/manage/electoral_coalitions_controller.rb
+++ b/app/controllers/manage/electoral_coalitions_controller.rb
@@ -9,9 +9,4 @@ class Manage::ElectoralCoalitionsController < ManageController
     end
   end
 
-  protected
-
-  def authorize_this!
-    authorize! :coalitions, @current_admin_user
-  end
 end

--- a/app/controllers/manage_controller.rb
+++ b/app/controllers/manage_controller.rb
@@ -6,7 +6,7 @@ class ManageController < ApplicationController
   protected
 
   def authorize_this!
-    raise "Not implemented"
+    authorize! :access, :manage_pages
   end
 
   def decide_encoding

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -45,6 +45,7 @@ class Ability
   # user.role == "admin"
   def admin(user)
     can :access, :admin
+    can :access, :manage_pages
     can :manage, :all
   end
 

--- a/spec/requests/manage_pages_spec.rb
+++ b/spec/requests/manage_pages_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe "Manage pages authorization" do
+  before { create(:global_configuration) }
+
+  it "allows admins" do
+    sign_in create(:admin_user)
+
+    get manage_candidates_path
+    expect(response).to have_http_status(:ok)
+
+    get manage_danger_zone_path
+    expect(response).to have_http_status(:ok)
+
+    get manage_candidate_attribute_changes_path
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "shows the manage links on the admin dashboard" do
+    sign_in create(:admin_user)
+
+    get admin_dashboard_path
+    expect(response.body).to include("Ylläpidon toiminnot")
+  end
+
+  it "redirects guests to the admin login" do
+    get manage_candidates_path
+    expect(response).to redirect_to(new_admin_user_session_path)
+  end
+
+  it "redirects Haka users to the admin login" do
+    sign_in_haka "012345678"
+
+    get manage_candidates_path
+    expect(response).to redirect_to(new_admin_user_session_path)
+  end
+end


### PR DESCRIPTION
Plan item **1.4** (security/robustness).

All `Manage::*Controller#authorize_this!` methods called `authorize! :something, @current_admin_user`, but `@current_admin_user` is nil at argument-evaluation time (Devise memoizes the instance variable only when the *method* is called). Admin access worked only because `can :manage, :all` happens to match a nil subject; the secretary role was denied by accident (which matches current intent — manage pages are admin-only — but by luck, not by design).

**Fix:**
- `can :access, :manage_pages` granted explicitly to the admin role in `ability.rb`
- one `authorize! :access, :manage_pages` in the `ManageController` base class; the six per-controller overrides are deleted (−29 lines)
- the dashboard "Ylläpidon toiminnot" panel renders only `if can? :access, :manage_pages` (mostly moot once the secretary role is removed in Phase 4, but it is the correct expression of intent)

Request specs: manage pages return 200 for admin, dashboard shows the panel, guests and Haka users are redirected to the admin login.

Base: `test-infrastructure` (#63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)