### PR TITLE
Restrict advocate team alliance access to read-only

### DIFF
--- a/app/controllers/advocates/alliances_controller.rb
+++ b/app/controllers/advocates/alliances_controller.rb
@@ -59,16 +59,20 @@ class Advocates::AlliancesController < AdvocatesController
 
   # Return either
   # - alliance of mine (which is not linked to coalition yet)
-  # - or alliance through AdvocateTeam (user A is viewing alliance of user B of the same team)
+  # - or, for read-only :show, alliance through AdvocateTeam (user A is
+  #   viewing alliance of user B of the same team). Team membership grants
+  #   read access only: edit/update resolve strictly through my own alliances.
   def find_alliance
     @alliance = current_advocate_user.electoral_alliances.find_by(id: params[:id])
 
-    if @alliance.nil? && current_advocate_user.advocate_team.present?
-      @alliance = current_advocate_user.advocate_team.electoral_alliances.find(params[:id])
+    if @alliance.nil? && action_name == "show" && current_advocate_user.advocate_team.present?
+      @alliance = current_advocate_user.advocate_team.electoral_alliances.find_by(id: params[:id])
     end
-  rescue ActiveRecord::RecordNotFound
-    flash.alert = "Pyydettyä vaaliliittoa ei löytynyt tai sinulla ei ole oikeuksia siihen."
-    redirect_to advocates_alliances_path
+
+    if @alliance.nil?
+      flash.alert = "Pyydettyä vaaliliittoa ei löytynyt tai sinulla ei ole oikeuksia siihen."
+      redirect_to advocates_alliances_path
+    end
   end
 
   def nav_paths

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -16,6 +16,11 @@ FactoryBot.define do
     advocate_login_enabled { true }
   end
 
+  factory :advocate_team do
+    sequence(:name) {|n| "Team #{n}"}
+    association :primary_advocate_user, factory: :advocate_user
+  end
+
   factory :faculty do
     sequence(:name) {|n| "Faculty #{n}"}
     sequence(:code) {|n| "F#{n}"}

--- a/spec/requests/advocates_alliances_spec.rb
+++ b/spec/requests/advocates_alliances_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+describe "Advocate alliance access" do
+  before { create(:global_configuration) }
+
+  let(:team) { create(:advocate_team) }
+  let(:owner) do
+    create(:advocate_user, student_number: "111", advocate_team: team)
+  end
+  let(:teammate) do
+    create(:advocate_user, student_number: "222", advocate_team: team)
+  end
+  let(:coalition) { create(:electoral_coalition, advocate_team: team) }
+  let!(:alliance) do
+    create(:electoral_alliance,
+      electoral_coalition: coalition,
+      advocate_user: owner,
+      name: "Alkuperäinen nimi")
+  end
+
+  describe "a team member who does not own the alliance" do
+    before { sign_in_haka teammate.student_number }
+
+    it "can view it" do
+      get advocates_alliance_path(alliance)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "cannot open the edit form" do
+      get edit_advocates_alliance_path(alliance)
+      expect(response).to redirect_to(advocates_alliances_path)
+    end
+
+    it "cannot update it" do
+      patch advocates_alliance_path(alliance),
+        params: { electoral_alliance: { name: "Muutettu nimi" } }
+
+      expect(response).to redirect_to(advocates_alliances_path)
+      expect(alliance.reload.name).to eq "Alkuperäinen nimi"
+    end
+  end
+
+  describe "the owning advocate" do
+    before { sign_in_haka owner.student_number }
+
+    it "can update the alliance" do
+      patch advocates_alliance_path(alliance),
+        params: { electoral_alliance: { name: "Muutettu nimi" } }
+
+      expect(alliance.reload.name).to eq "Muutettu nimi"
+    end
+  end
+
+  describe "an advocate without a team" do
+    let(:outsider) { create(:advocate_user, student_number: "333") }
+
+    before { sign_in_haka outsider.student_number }
+
+    it "is redirected instead of crashing when viewing a foreign alliance" do
+      get advocates_alliance_path(alliance)
+      expect(response).to redirect_to(advocates_alliances_path)
+    end
+  end
+end


### PR DESCRIPTION
Plan items **1.5** (security) and **2.3** (crash) — one diff, as planned.

**1.5:** `Advocates::AlliancesController#find_alliance` fell back to `advocate_team.electoral_alliances` for `:show, :edit, :update` alike, so any team member could edit another member's alliance. Team membership grants read-only access by intent. The team fallback now applies only to `show`; `edit`/`update` resolve strictly via the advocate's own alliances.

**2.3:** the same method returned nil (instead of raising) for an advocate *without* a team requesting a foreign alliance id, and the view then crashed with a 500. Both lookups now use `find_by`, and a nil result redirects to the alliance list with the existing alert.

Request specs: team member can view but not edit/update a teammate's alliance (name stays unchanged), owner can update, team-less advocate is redirected instead of 500. 3/5 fail without the fix (the other two pin pre-existing correct behavior).

Base: `test-infrastructure` (#63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)