### PR TITLE
Lengthen generated initial password to 20 characters

### DIFF
--- a/app/concerns/devise_user_behaviour.rb
+++ b/app/concerns/devise_user_behaviour.rb
@@ -12,7 +12,7 @@ module DeviseUserBehaviour
     # Generate a password only if it was not set manually (when password_confirmation is present)
     def generate_password
       if password_confirmation.nil?
-        self.password = Devise.friendly_token.first(8)
+        self.password = Devise.friendly_token.first(20)
       end
     end
 

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -9,4 +9,9 @@ describe AdminUser do
     expect(user.encrypted_password).not_to eq ""
   end
 
+  it "generates a 20 character initial password" do
+    user = create(:admin_user)
+    expect(user.password.length).to eq 20
+  end
+
 end


### PR DESCRIPTION
Plan item **1.6** (security).

Per the review decision the email-the-initial-password flow stays (operationally convenient for HYY), but the generated password grows from 8 to 20 characters of `Devise.friendly_token`.

One-line fix in `DeviseUserBehaviour#generate_password` (only `AdminUser` includes the concern) plus a model spec.

Base: `test-infrastructure` (#63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)