### PR TITLE
Scope advocate candidate updates to own alliances in ability

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -94,11 +94,11 @@ class Ability
       can [:create, :update], ElectoralAlliance
       can [:create, :update], ElectoralCoalition
 
-      can [:update], Candidate
+      can [:update], Candidate, electoral_alliance: { primary_advocate_id: user.advocate_user.id }
     end
 
     if GlobalConfiguration.candidate_data_correction_period?
-      can [:update], Candidate
+      can [:update], Candidate, electoral_alliance: { primary_advocate_id: user.advocate_user.id }
       cannot [:create], ElectoralAlliance
     end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe Ability do
+  describe "advocate user during nomination period" do
+    let(:advocate) { create(:advocate_user) }
+    let(:haka_user) do
+      HakaUser.new(attrs: {
+        student_number: ["#{Vaalit::Haka::HAKA_STUDENT_NUMBER_KEY}:#{advocate.student_number}"]
+      })
+    end
+
+    before { create(:global_configuration) }
+
+    it "can update candidates only in own alliances" do
+      own_candidate = create(:candidate,
+        electoral_alliance: create(:electoral_alliance, advocate_user: advocate))
+      foreign_candidate = create(:candidate)
+
+      ability = Ability.new(haka_user)
+
+      expect(ability.can?(:update, own_candidate)).to eq true
+      expect(ability.can?(:update, foreign_candidate)).to eq false
+    end
+
+    it "still allows a haka user to update their own candidacy" do
+      own_candidacy = create(:candidate, student_number: advocate.student_number)
+
+      expect(Ability.new(haka_user).can?(:update, own_candidacy)).to eq true
+    end
+  end
+end


### PR DESCRIPTION
Plan item **1.9** (security, defense in depth).

`Ability#advocate_user` granted a *global* `can [:update], Candidate` — only the controller-level lookup kept advocates inside their own alliances. The ability itself is now scoped:

```ruby
can [:update], Candidate, electoral_alliance: { primary_advocate_id: user.advocate_user.id }
```

applied to both the nomination-period and correction-period grants. Inside `advocate_user(user)` the `user` is the **HakaUser**, hence `user.advocate_user.id`. The haka user's own-candidacy rules (`student_number: ...`) are separate `can` rules and OR together — the second spec pins that they still work.

Ability specs: own-alliance candidate updatable, foreign candidate not (fails without the fix), own candidacy unaffected.

Base: `test-infrastructure` (#63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)