### PR TITLE
Guard registration actions against a missing candidate

### DIFF
--- a/app/controllers/registrations/candidates_controller.rb
+++ b/app/controllers/registrations/candidates_controller.rb
@@ -4,12 +4,9 @@ class Registrations::CandidatesController < RegistrationsController
   before_action :require_student_number
   before_action :set_invite_code
   before_action :set_candidate
+  before_action :require_candidate, :only => [:edit, :update, :cancel]
 
   def edit
-    if @candidate.nil?
-      flash.alert = "Ehdokasilmoittautuminen ei ole voimassa."
-      redirect_to registrations_candidate_path and return
-    end
   end
 
   def show
@@ -75,6 +72,12 @@ class Registrations::CandidatesController < RegistrationsController
   # - find alliance by invite_code so one can only apply to an alliance they have been invited to
   def create
     @alliance = find_alliance
+
+    if @alliance.nil?
+      flash.alert = "Kutsukoodi \"#{@invite_code_upcase}\" ei ole voimassa."
+      redirect_to registrations_root_path and return
+    end
+
     @candidate = Candidate.new(candidate_params).tap do |t|
       t.student_number = current_haka_user.student_number # sensitive
       t.electoral_alliance = @alliance # sensitive
@@ -105,6 +108,15 @@ class Registrations::CandidatesController < RegistrationsController
 
   def set_candidate
     @candidate = Candidate.valid.find_by(student_number: current_haka_user.student_number)
+  end
+
+  # Guards against a stale browser tab: double-cancel or resubmitting the
+  # edit form after the candidacy has been cancelled.
+  def require_candidate
+    if @candidate.nil?
+      flash.alert = "Ehdokasilmoittautuminen ei ole voimassa."
+      redirect_to registrations_candidate_path
+    end
   end
 
   def find_alliance

--- a/spec/requests/registrations_candidates_spec.rb
+++ b/spec/requests/registrations_candidates_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+describe "Candidate registration" do
+  let(:student_number) { "012345678" }
+
+  before { sign_in_haka student_number }
+
+  describe "after the candidacy has been cancelled" do
+    before do
+      create(:candidate, student_number: student_number).cancel
+    end
+
+    it "cancelling again redirects instead of crashing" do
+      post cancel_registrations_candidate_path
+
+      expect(response).to redirect_to(registrations_candidate_path)
+      expect(flash[:alert]).to be_present
+    end
+
+    it "resubmitting the edit form redirects instead of crashing" do
+      patch registrations_candidate_path,
+        params: { candidate: { phone_number: "040123" } }
+
+      expect(response).to redirect_to(registrations_candidate_path)
+      expect(flash[:alert]).to be_present
+    end
+  end
+
+  describe "creating with a stale invite code" do
+    it "redirects to the registration front page instead of crashing" do
+      post registrations_candidate_path, params: {
+        invite_code: "EIOO",
+        candidate: {
+          lastname: "Meikäläinen",
+          firstname: "Matti",
+          candidate_name: "Meikäläinen, Matti",
+          email: "matti@example.com"
+        }
+      }
+
+      expect(response).to redirect_to(registrations_root_path)
+      expect(flash[:alert]).to include("ei ole voimassa")
+      expect(Candidate.count).to eq 0
+    end
+  end
+
+  describe "creating with a valid invite code" do
+    it "creates the candidate" do
+      alliance = create(:electoral_alliance, invite_code: "KOODI")
+
+      post registrations_candidate_path, params: {
+        invite_code: "koodi",
+        candidate: {
+          lastname: "Meikäläinen",
+          firstname: "Matti",
+          candidate_name: "Meikäläinen, Matti",
+          email: "matti@example.com"
+        }
+      }
+
+      expect(response).to redirect_to(registrations_candidate_path(student_number))
+      expect(alliance.candidates.count).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
Plan items **2.1** and **2.2** (crash bugs in normal use).

**2.1:** `edit` guarded `@candidate.nil?` but `update` and `cancel` did not — a double-cancel or a back-button form resubmit raised `NoMethodError` (500). The guard is now one shared `before_action` for all three actions, redirecting with the existing alert text.

**2.2:** `create` with a stale invite code found no alliance, failed validation, rendered `new`, and crashed on `@alliance.name`. It now redirects to the registration front page with the existing "Kutsukoodi ei ole voimassa" alert.

Request specs: double-cancel, resubmit-after-cancel, stale-code create (3/4 fail without the fix), plus a happy-path create as a baseline.

Base: `test-infrastructure` (#63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)