### PR TITLE
Block destroying an alliance that has candidates

### DIFF
--- a/app/controllers/manage/danger_zones_controller.rb
+++ b/app/controllers/manage/danger_zones_controller.rb
@@ -10,7 +10,7 @@ class Manage::DangerZonesController < ManageController
       redirect_to manage_danger_zone_path, alert: <<-MSG.squish
         Kaikki liitot eivät ole valmiina,
         renkailta puuttuu järjestys
-        tai kaikilla ehdokkailla ei ole liittoa.
+        tai kaikilla liitoilla ei ole rengasta.
       MSG
     end
   end

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -17,7 +17,6 @@ class Candidate < ActiveRecord::Base
 
   scope :cancelled, -> { where(:cancelled => true).order("cancelled_at desc") }
   scope :valid, -> { where(:cancelled => false) }
-  scope :without_alliance, -> { where(:electoral_alliance_id => nil) }
 
   # by_numbering_order is the order in which candidate numbers will be assigned.
   # Cancelled candidates are not included in the result.
@@ -88,7 +87,6 @@ class Candidate < ActiveRecord::Base
   def self.can_give_numbers?
     ElectoralAlliance.are_all_ready? &&
       ElectoralCoalition.are_all_ordered? &&
-      Candidate.without_alliance.empty? &&
       ElectoralAlliance.without_coalition.empty?
   end
 

--- a/app/models/electoral_alliance.rb
+++ b/app/models/electoral_alliance.rb
@@ -5,7 +5,9 @@ class ElectoralAlliance < ActiveRecord::Base
     with: /\A[A-Za-z0-9-]+\z/,
     message: "allows only English alphanumeric and - characters"
 
-  has_many :candidates, :dependent => :nullify
+  # candidates.electoral_alliance_id is NOT NULL with a foreign key:
+  # an alliance that has (ever had) candidates must not be destroyed.
+  has_many :candidates, :dependent => :restrict_with_error
 
   # Each Candidate needs to be accepted to the Alliance by its AdvocateUser.
   has_many :accepted_candidates, -> {

--- a/spec/models/electoral_alliance_spec.rb
+++ b/spec/models/electoral_alliance_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe ElectoralAlliance do
+  describe "#destroy" do
+    it "is blocked when the alliance has candidates" do
+      alliance = create(:electoral_alliance)
+      create(:candidate, electoral_alliance: alliance)
+
+      expect(alliance.destroy).to eq false
+      expect(alliance.errors[:base]).to be_present
+      expect(ElectoralAlliance.exists?(alliance.id)).to eq true
+    end
+
+    it "destroys an alliance without candidates" do
+      alliance = create(:electoral_alliance)
+
+      expect(alliance.destroy).to be_truthy
+      expect(ElectoralAlliance.exists?(alliance.id)).to eq false
+    end
+  end
+end

--- a/spec/requests/admin_alliance_destroy_spec.rb
+++ b/spec/requests/admin_alliance_destroy_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe "Admin electoral alliance destroy" do
+  before { sign_in create(:admin_user) }
+
+  it "refuses to destroy an alliance with candidates and shows an alert" do
+    alliance = create(:electoral_alliance)
+    create(:candidate, electoral_alliance: alliance)
+
+    delete admin_electoral_alliance_path(alliance)
+
+    expect(ElectoralAlliance.exists?(alliance.id)).to eq true
+    expect(flash[:alert]).to be_present
+  end
+
+  it "destroys an alliance without candidates" do
+    alliance = create(:electoral_alliance)
+
+    delete admin_electoral_alliance_path(alliance)
+
+    expect(ElectoralAlliance.exists?(alliance.id)).to eq false
+  end
+end


### PR DESCRIPTION
Plan item **2.4** (crash bug).

`has_many :candidates, dependent: :nullify` conflicted with the `NOT NULL` + FK constraint on `candidates.electoral_alliance_id` — destroying an alliance that ever had a candidate always 500'd with a Postgres error. The invariant *a candidate always has an alliance* is confirmed, so the destroy must be refused instead: `dependent: :restrict_with_error`. The NOT NULL stays. ActiveAdmin's responder already turns the model error into a flash alert (pinned by a request spec), so no controller override was needed.

Also removes the orphan-candidate fossils that are provably dead under the NOT NULL invariant (as agreed during review): `Candidate.without_alliance` scope and the orphan check in `can_give_numbers?`; the danger zone alert now lists the remaining reasons.

Specs: model-level destroy blocked/allowed, admin request destroy blocked with alert / allowed when empty.

Base: `test-infrastructure` (#63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)