### PR TITLE
Nil guards in model callbacks and helpers

### DIFF
--- a/app/models/electoral_alliance.rb
+++ b/app/models/electoral_alliance.rb
@@ -30,7 +30,6 @@ class ElectoralAlliance < ActiveRecord::Base
   validates_uniqueness_of :shorten, :name, :invite_code
 
   validates_length_of :shorten, :in => 2..6
-  validates_presence_of :expected_candidate_count, :allow_nil => true
   validates :expected_candidate_count, numericality: { only_integer: true, in: 1..60 }
 
   before_validation :strip_whitespace_from_name_fields!
@@ -58,7 +57,7 @@ class ElectoralAlliance < ActiveRecord::Base
   end
 
   def has_all_candidates?
-    expected_candidate_count > 0 && accepted_candidates.count == expected_candidate_count
+    expected_candidate_count.to_i > 0 && accepted_candidates.count == expected_candidate_count
   end
 
   def to_csv(encoding)
@@ -82,11 +81,11 @@ class ElectoralAlliance < ActiveRecord::Base
   protected
 
   def strip_whitespace_from_name_fields!
-    self.name.strip!
-    self.shorten.strip!
+    self.name&.strip!
+    self.shorten&.strip!
   end
 
   def upcase_invite_code!
-    self.invite_code.upcase!
+    self.invite_code&.upcase!
   end
 end

--- a/app/models/electoral_coalition.rb
+++ b/app/models/electoral_coalition.rb
@@ -47,7 +47,7 @@ class ElectoralCoalition < ActiveRecord::Base
   protected
 
   def strip_whitespace_from_name_fields!
-    self.name.strip!
-    self.shorten.strip!
+    self.name&.strip!
+    self.shorten&.strip!
   end
 end

--- a/app/models/global_configuration.rb
+++ b/app/models/global_configuration.rb
@@ -43,7 +43,7 @@ class GlobalConfiguration < ActiveRecord::Base
   end
 
   def self.advocate_login_enabled?
-    return first.advocate_login_enabled?
+    !!first&.advocate_login_enabled?
   end
 
   def enable_advocate_login!

--- a/spec/models/nil_guards_spec.rb
+++ b/spec/models/nil_guards_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+# Regression specs: nil input must produce a validation error or a false
+# return value, never a NoMethodError.
+describe "Nil guards" do
+  describe ElectoralAlliance do
+    it "is invalid without a name instead of crashing in before_validation" do
+      alliance = build(:electoral_alliance, name: nil, shorten: nil, invite_code: nil)
+
+      expect(alliance.valid?).to eq false
+      expect(alliance.errors[:name]).to be_present
+    end
+
+    it "is invalid without expected_candidate_count" do
+      alliance = build(:electoral_alliance, expected_candidate_count: nil)
+
+      expect(alliance.valid?).to eq false
+      expect(alliance.errors[:expected_candidate_count]).to be_present
+    end
+
+    it "has_all_candidates? is false when expected_candidate_count is nil" do
+      alliance = build(:electoral_alliance, expected_candidate_count: nil)
+
+      expect(alliance.has_all_candidates?).to eq false
+    end
+  end
+
+  describe ElectoralCoalition do
+    it "is invalid without a name instead of crashing in before_validation" do
+      coalition = build(:electoral_coalition, name: nil, shorten: nil)
+
+      expect(coalition.valid?).to eq false
+      expect(coalition.errors[:name]).to be_present
+    end
+  end
+
+  describe GlobalConfiguration do
+    it "advocate_login_enabled? is false when the table is empty" do
+      expect(GlobalConfiguration.count).to eq 0
+      expect(GlobalConfiguration.advocate_login_enabled?).to eq false
+    end
+  end
+end


### PR DESCRIPTION
Plan items **2.5**, **2.7**, **2.9** (crash bugs) and **3.5** (dead validation).

- **2.5:** `strip_whitespace_from_name_fields!` and `upcase_invite_code!` (`before_validation`) raised `NoMethodError` on nil input instead of producing a validation error. Safe navigation; `Candidate#strip_whitespace!` is `before_save` (post-validation) and stays untouched.
- **2.7:** `GlobalConfiguration.advocate_login_enabled?` crashed on an empty table — now `!!first&.advocate_login_enabled?`.
- **2.9:** one legacy row with nil `expected_candidate_count` killed the whole admin dashboard via `has_all_candidates?` — now `expected_candidate_count.to_i > 0`.
- **3.5:** `validates_presence_of :expected_candidate_count, allow_nil: true` is a no-op; deleted. The numericality rule still rejects nil (pinned by spec).

Model specs for each; 4/5 fail without the fixes.

Base: `test-infrastructure` (#63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)