### PR TITLE
Skip numbering-order update when params are missing

### DIFF
--- a/app/admin/electoral_coalitions.rb
+++ b/app/admin/electoral_coalitions.rb
@@ -119,7 +119,7 @@ ActiveAdmin.register ElectoralCoalition do
 
   member_action :order_alliances, :method => :post do
     coalition = ElectoralCoalition.find_by_id(params[:id])
-    coalition.update_alliance_numbering_order!(params[:alliances])
+    coalition.update_alliance_numbering_order!(params[:alliances]) if params[:alliances].present?
     redirect_to admin_electoral_coalition_path(coalition.id)
   end
 
@@ -127,7 +127,7 @@ ActiveAdmin.register ElectoralCoalition do
     if ElectoralAlliance.without_coalition.count > 0
       redirect_to admin_electoral_coalitions_path, :alert => 'Vaalirenkaita ei voi järjestää ennen kuin kaikilla vaaliliitoilla on rengas. Luo itsenäisille vaaliliitoille rengas, jonka nimenä on vaaliliiton nimi.'
     else
-      ElectoralCoalition.update_coalition_numbering_order!(params[:coalitions])
+      ElectoralCoalition.update_coalition_numbering_order!(params[:coalitions]) if params[:coalitions].present?
       redirect_to admin_electoral_coalitions_path
     end
   end

--- a/spec/requests/admin_numbering_order_spec.rb
+++ b/spec/requests/admin_numbering_order_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe "Admin numbering order endpoints" do
+  before { sign_in create(:admin_user) }
+
+  let!(:coalition) { create(:electoral_coalition) }
+  let!(:alliance) { create(:electoral_alliance, electoral_coalition: coalition) }
+
+  it "orders alliances within a coalition" do
+    post order_alliances_admin_electoral_coalition_path(coalition),
+      params: { alliances: { alliance.id.to_s => "7" } }
+
+    expect(response).to redirect_to(admin_electoral_coalition_path(coalition.id))
+    expect(alliance.reload.numbering_order).to eq 7
+  end
+
+  it "does not crash when the alliances param is missing" do
+    post order_alliances_admin_electoral_coalition_path(coalition)
+
+    expect(response).to redirect_to(admin_electoral_coalition_path(coalition.id))
+  end
+
+  it "does not crash when the coalitions param is missing" do
+    post order_coalitions_admin_electoral_coalitions_path
+
+    expect(response).to redirect_to(admin_electoral_coalitions_path)
+  end
+end


### PR DESCRIPTION
Plan item **2.8** (crash bug).

The `order_alliances` member action and `order_coalitions` collection action passed possibly-nil `params[:alliances]` / `params[:coalitions]` into `.each` — a 500 whenever the sortable form posts empty. One-line `present?` guard in each action; the redirect stays the same.

Request specs: missing params redirect instead of crashing (2/3 fail without the fix), plus a happy-path ordering assertion.

Base: `test-infrastructure` (#63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)