### PR TITLE
Declare has_many ids as array in permit_params

### DIFF
--- a/app/admin/advocate_teams.rb
+++ b/app/admin/advocate_teams.rb
@@ -1,43 +1,9 @@
 ActiveAdmin.register AdvocateTeam do
   permit_params :name,
-    :advocate_user_ids,
-    :primary_advocate_user_id
+    :primary_advocate_user_id,
+    :advocate_user_ids => []
 
   menu :label => " Tiimit", :priority => 20
-
-  controller do
-    # Override default method because :advocate_user_ids is not available in permitted_params.
-    def create
-      @advocate_team = AdvocateTeam.new(permitted_params[:advocate_team])
-
-      @advocate_team.advocate_user_ids = permitted_params[:advocate_user_ids]
-
-      if @advocate_team.save
-        @advocate_team.update!(advocate_user_ids: params[:advocate_team][:advocate_user_ids])
-
-        flash.notice = "Edustajatiimi luotu!"
-        redirect_to admin_advocate_team_path(@advocate_team)
-      else
-        flash.alert = "Edustajatiimin luominen epäonnistui: #{@advocate_team.errors.full_messages}"
-        super
-      end
-    end
-
-    # Override default method because :advocate_user_ids is not available in permitted_params.
-    def update
-      @advocate_team = AdvocateTeam.find(params[:id])
-
-      if @advocate_team.update(permitted_params[:advocate_team])
-        @advocate_team.update!(advocate_user_ids: params[:advocate_team][:advocate_user_ids])
-
-        flash.notice = "Muutokset tallennettu!"
-        redirect_to admin_advocate_team_path(@advocate_team)
-      else
-        flash.alert = "Tallennus epäonnistui: #{@advocate_team.errors.full_messages}"
-        super
-      end
-    end
-  end
 
   index do
     column "Edustajatiimin nimi", :name

--- a/app/admin/advocate_users.rb
+++ b/app/admin/advocate_users.rb
@@ -5,42 +5,9 @@ ActiveAdmin.register AdvocateUser do
                 :firstname,
                 :lastname,
                 :phone_number,
-                :electoral_alliance_ids
+                :electoral_alliance_ids => []
 
   menu :label => "Edustajatunnukset", :if => proc { can? :manage, AdvocateUser }, :priority => 12
-
-  controller do
-
-    # Override default method because :electoral_alliance_ids is just not
-    # available through permitted_params.
-    def update
-      @advocate_user = AdvocateUser.find(params[:id])
-
-      if @advocate_user.update(permitted_params[:advocate_user])
-        @advocate_user.update! electoral_alliance_ids: params[:advocate_user][:electoral_alliance_ids]
-
-        flash[:notice] = "Muutokset tallennettu."
-        redirect_to admin_advocate_user_path(@advocate_user)
-      else
-        super
-      end
-    end
-
-    # Override default method because :electoral_alliance_ids is just not
-    # available through permitted_params.
-    def create
-      @advocate_user = AdvocateUser.new(permitted_params[:advocate_user])
-
-      if @advocate_user.save
-        @advocate_user.update! electoral_alliance_ids: params[:advocate_user][:electoral_alliance_ids]
-
-        flash[:notice] = "Edustaja luotu!"
-        redirect_to admin_advocate_user_path(@advocate_user)
-      else
-        super
-      end
-    end
-  end
 
   index do
     column :lastname

--- a/app/admin/electoral_coalitions.rb
+++ b/app/admin/electoral_coalitions.rb
@@ -2,41 +2,9 @@ ActiveAdmin.register ElectoralCoalition do
   permit_params :name,
                 :shorten,
                 :advocate_team_id,
-                :electoral_alliance_ids
+                :electoral_alliance_ids => []
 
   menu :label => " Vaalirenkaat", :priority => 2
-
-  controller do
-    # Override default method because :electoral_alliance_ids is not available in permitted_params.
-    def update
-      @electoral_coalition = ElectoralCoalition.find(params[:id])
-
-      if @electoral_coalition.update(permitted_params[:electoral_coalition])
-        @electoral_coalition.update! electoral_alliance_ids: params[:electoral_coalition][:electoral_alliance_ids]
-
-        flash.notice = "Muutokset tallennettu."
-        redirect_to admin_electoral_coalition_path(@electoral_coalition)
-      else
-        flash.alert = "Tallennus epäonnistui: #{@electoral_coalition.errors.full_messages}"
-        super
-      end
-    end
-
-    # Override default method because :electoral_alliance_ids is not available in permitted_params.
-    def create
-      @electoral_coalition = ElectoralCoalition.new(permitted_params[:electoral_coalition])
-
-      if @electoral_coalition.save
-        @electoral_coalition.update! electoral_alliance_ids: params[:electoral_coalition][:electoral_alliance_ids]
-
-        flash.notice = "Vaalirengas luotu!"
-        redirect_to admin_electoral_coalition_path(@electoral_coalition)
-      else
-        flash.alert = "Tallennus epäonnistui: #{@electoral_coalition.errors.full_messages}"
-        super
-      end
-    end
-  end
 
   index do
     column("Vaalirenkaan nimi") { |c| link_to c.name, admin_electoral_coalition_path(c) }

--- a/spec/requests/admin_has_many_ids_spec.rb
+++ b/spec/requests/admin_has_many_ids_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+# The has_many ids checkbox groups submit arrays. permit_params must declare
+# them array-style (ids: []) or strong parameters silently drops them — the
+# root cause behind the former create/update controller overrides.
+describe "Admin has_many ids assignment" do
+  before { sign_in create(:admin_user) }
+
+  it "creates an advocate team with the selected advocates" do
+    primary = create(:advocate_user)
+    member = create(:advocate_user)
+
+    post admin_advocate_teams_path, params: {
+      advocate_team: {
+        name: "Tiimi",
+        primary_advocate_user_id: primary.id,
+        advocate_user_ids: ["", member.id.to_s]
+      }
+    }
+
+    team = AdvocateTeam.find_by(name: "Tiimi")
+    expect(team).to be_present
+    expect(team.advocate_users).to include(member)
+  end
+
+  it "updates a coalition's alliances, including clearing the selection" do
+    coalition = create(:electoral_coalition)
+    alliance = create(:electoral_alliance, electoral_coalition: nil)
+
+    patch admin_electoral_coalition_path(coalition), params: {
+      electoral_coalition: { electoral_alliance_ids: ["", alliance.id.to_s] }
+    }
+    expect(coalition.reload.electoral_alliances).to include(alliance)
+
+    # Empty checkbox group submits only the blank hidden field.
+    patch admin_electoral_coalition_path(coalition), params: {
+      electoral_coalition: { electoral_alliance_ids: [""] }
+    }
+    expect(coalition.reload.electoral_alliances).to be_empty
+  end
+
+  it "updates an advocate's alliances" do
+    advocate = create(:advocate_user)
+    alliance = create(:electoral_alliance)
+
+    patch admin_advocate_user_path(advocate), params: {
+      advocate_user: { electoral_alliance_ids: ["", alliance.id.to_s] }
+    }
+
+    expect(advocate.reload.electoral_alliances).to include(alliance)
+  end
+end


### PR DESCRIPTION
Plan item **2.6** (crash + admin-only mass-assignment bypass). Root cause confirmed from git history (commit `909f5ea`, 2016 Rails 5 migration).

`permit_params` declared `:electoral_alliance_ids` / `:advocate_user_ids` as **scalars**, but the checkbox forms submit **arrays** — strong params silently drops an array under a scalar key (hence the old comment *"just not available through permitted_params"*). The workaround assigned `*_ids` from raw `params` in create/update overrides: a strong-parameters bypass that crashed whenever the checkbox group was absent (plus one dead wrong-key line in advocate_teams). The workaround was later copy-pasted to two more resources.

**Fix:** array-style `permit_params ..., ids: []` in `advocate_teams`, `advocate_users` and `electoral_coalitions`; all six controller overrides deleted (−80 lines). The custom Finnish flash notices existed only to serve the workaround and go with it (ActiveAdmin defaults apply).

Request specs: team create with member selection, coalition alliance assignment **and clearing via the blank hidden field**, advocate alliance assignment.

⚠️ Manual QA after merge (per plan): create+edit team / advocate / coalition in the admin UI, including an empty checkbox selection.

Base: `test-infrastructure` (#63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)