### PR TITLE
Write candidate audit log only after a successful save

### DIFF
--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -117,8 +117,17 @@ class Candidate < ActiveRecord::Base
   def log_and_update_attributes(attrs)
     Candidate.transaction do
       self.assign_attributes(attrs)
-      CandidateAttributeChange.create_from!(self.id, self.changes) if self.changed? and GlobalConfiguration.log_candidate_attribute_changes?
-      self.save
+      changed_keys = self.changed
+
+      # Log only after a successful save: a failed save must not leave
+      # phantom rows in the legally relevant change log.
+      next false unless self.save
+
+      if changed_keys.any? and GlobalConfiguration.log_candidate_attribute_changes?
+        CandidateAttributeChange.create_from!(self.id, self.previous_changes.slice(*changed_keys))
+      end
+
+      true
     end
   end
 

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -1,6 +1,34 @@
 require 'spec_helper'
 
 describe Candidate do
+  describe "#log_and_update_attributes" do
+    before do
+      allow(GlobalConfiguration).to receive(:log_candidate_attribute_changes?).and_return(true)
+    end
+
+    it "writes no audit rows when the save fails" do
+      candidate = FactoryBot.create(:candidate)
+
+      result = candidate.log_and_update_attributes(email: "")
+
+      expect(result).to eq false
+      expect(CandidateAttributeChange.count).to eq 0
+    end
+
+    it "writes audit rows for the changed attributes on success" do
+      candidate = FactoryBot.create(:candidate)
+
+      result = candidate.log_and_update_attributes(phone_number: "040 555 6677")
+
+      expect(result).to eq true
+
+      changes = CandidateAttributeChange.where(candidate_id: candidate.id)
+      expect(changes.count).to eq 1
+      expect(changes.first.attribute_name).to eq "phone_number"
+      expect(changes.first.new_value).to eq "040 555 6677"
+    end
+  end
+
   it 'can give candidate numbers' do
     2.times do |i|
       coalition = FactoryBot.create(:electoral_coalition)


### PR DESCRIPTION
Plan item **3.1** (data integrity — the change log is the legally relevant record).

`Candidate#log_and_update_attributes` wrote `CandidateAttributeChange` rows *before* `save`. A failed validation returns `false` without raising, so the surrounding transaction happily committed audit rows for a change that never happened.

**Fix:** save first; on success, log the originally assigned attribute keys from `previous_changes` — so the log now records the values as actually persisted (e.g. after whitespace stripping), which the old pre-save snapshot did not. Return contract unchanged (used by `cancel`, `confirm_alliance!` and both candidate controllers).

Regression specs: failed update → zero log rows (fails without the fix); successful update → exactly the changed attribute with its persisted value.

Base: `test-infrastructure` (#63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)