### PR TITLE
Give candidate numbers with nil reset and unique indexes

### DIFF
--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -96,7 +96,9 @@ class Candidate < ActiveRecord::Base
     return false unless can_give_numbers?
 
     Candidate.transaction do
-      Candidate.update_all :candidate_number => 0
+      # Cancelled candidates must not have a number; NULL also satisfies the
+      # unique index on candidate_number.
+      Candidate.update_all :candidate_number => nil
 
       candidates_in_order = Candidate
         .select('candidates.*')

--- a/db/migrate/20260707120001_add_unique_index_to_candidate_number.rb
+++ b/db/migrate/20260707120001_add_unique_index_to_candidate_number.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexToCandidateNumber < ActiveRecord::Migration[8.0]
+  def change
+    # Postgres allows multiple NULLs in a unique index, so cancelled
+    # candidates (candidate_number NULL) are fine.
+    add_index :candidates, :candidate_number, unique: true
+  end
+end

--- a/db/migrate/20260707120002_add_unique_index_to_advocate_student_number.rb
+++ b/db/migrate/20260707120002_add_unique_index_to_advocate_student_number.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexToAdvocateStudentNumber < ActiveRecord::Migration[8.0]
+  def change
+    # Haka login resolves advocates by student_number; the model-only
+    # uniqueness validation is race-prone without this index.
+    add_index :advocate_users, :student_number, unique: true
+  end
+end

--- a/db/migrate/20260707120003_remove_secondary_advocate_id_from_electoral_alliances.rb
+++ b/db/migrate/20260707120003_remove_secondary_advocate_id_from_electoral_alliances.rb
@@ -1,0 +1,7 @@
+class RemoveSecondaryAdvocateIdFromElectoralAlliances < ActiveRecord::Migration[8.0]
+  def change
+    # Unused since 2012.
+    remove_foreign_key :electoral_alliances, column: :secondary_advocate_id
+    remove_column :electoral_alliances, :secondary_advocate_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_05_130017) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_07_120003) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension "pg_catalog.plpgsql"
 
   create_table "active_admin_comments", id: :serial, force: :cascade do |t|
     t.integer "resource_id", null: false
@@ -94,6 +94,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_05_130017) do
     t.string "student_number", default: "", null: false
     t.integer "advocate_team_id"
     t.index ["email"], name: "index_advocate_users_on_email", unique: true
+    t.index ["student_number"], name: "index_advocate_users_on_student_number", unique: true
   end
 
   create_table "candidate_attribute_changes", id: :serial, force: :cascade do |t|
@@ -125,6 +126,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_05_130017) do
     t.string "postal_city"
     t.datetime "cancelled_at", precision: nil
     t.boolean "alliance_accepted", default: false, null: false
+    t.index ["candidate_number"], name: "index_candidates_on_candidate_number", unique: true
     t.index ["student_number"], name: "allow_single_non_cancelled_candidate_per_student_number", unique: true, where: "(cancelled IS NOT TRUE)"
   end
 
@@ -153,7 +155,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_05_130017) do
     t.datetime "updated_at", precision: nil
     t.string "shorten"
     t.integer "primary_advocate_id"
-    t.integer "secondary_advocate_id"
     t.string "invite_code", null: false
     t.index ["invite_code"], name: "index_electoral_alliances_on_invite_code", unique: true
   end
@@ -196,7 +197,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_05_130017) do
   add_foreign_key "candidate_attribute_changes", "candidates", name: "candidate_attribute_changes_candidate_id_fk"
   add_foreign_key "candidates", "electoral_alliances", name: "candidates_electoral_alliance_id_fk"
   add_foreign_key "electoral_alliances", "advocate_users", column: "primary_advocate_id", name: "electoral_alliances_primary_advocate_id_fk"
-  add_foreign_key "electoral_alliances", "advocate_users", column: "secondary_advocate_id", name: "electoral_alliances_secondary_advocate_id_fk"
   add_foreign_key "electoral_alliances", "electoral_coalitions", name: "electoral_alliances_electoral_coalition_id_fk"
   add_foreign_key "electoral_coalitions", "advocate_teams"
 end

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -24,4 +24,16 @@ describe Candidate do
       expect(c.candidate_number).to eq i
     end
   end
+
+  it 'leaves cancelled candidates without a candidate number' do
+    alliance = FactoryBot.create(:electoral_alliance)
+    FactoryBot.create_list(:candidate, 3, :electoral_alliance => alliance)
+    cancelled = FactoryBot.create(:candidate, :electoral_alliance => alliance)
+    cancelled.cancel
+
+    expect(Candidate.give_numbers!).to eq true
+
+    expect(cancelled.reload.candidate_number).to be_nil
+    expect(Candidate.valid.where(:candidate_number => nil)).to be_empty
+  end
 end

--- a/spec/models/db_constraints_spec.rb
+++ b/spec/models/db_constraints_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+# The unique indexes back up model validations that are race-prone on
+# their own (and give_numbers!, which bypasses validations entirely).
+describe "Database constraints" do
+  it "rejects duplicate candidate numbers" do
+    a = create(:candidate)
+    b = create(:candidate)
+    a.update_column(:candidate_number, 2)
+
+    expect {
+      b.update_column(:candidate_number, 2)
+    }.to raise_error(ActiveRecord::RecordNotUnique)
+  end
+
+  it "rejects duplicate advocate student numbers" do
+    advocate = create(:advocate_user)
+    copy = build(:advocate_user, student_number: advocate.student_number)
+
+    expect {
+      copy.save(validate: false)
+    }.to raise_error(ActiveRecord::RecordNotUnique)
+  end
+end


### PR DESCRIPTION
Plan items **3.2**, **3.3** (data integrity) and the Phase 4 `secondary_advocate_id` drop, bundled into one schema-changing deploy as agreed.

**3.2 — `give_numbers!` (order matters):**
1. `update_all candidate_number: 0` hit every row, so cancelled candidates kept `0` — but the column is exported and cancelled candidates must have no number. Reset is now `nil`.
2. New migration adds a **unique index on `candidates.candidate_number`**. Postgres allows multiple NULLs, so cancelled candidates are fine. The 0→nil fix is a prerequisite — the old reset would violate the index on the second run. Numbering still starts at 2 (election convention, untouched).

**3.3 —** unique index on `advocate_users.student_number` (Haka login resolves advocates by student number; the model validation alone is race-prone).

**Phase 4 —** drop `electoral_alliances.secondary_advocate_id` + FK, unused since 2012, zero code references.

Specs: cancelled candidate keeps NULL after numbering (fails without the fix — with the index in place the old code can't even run), duplicate candidate_number / advocate student_number raise `RecordNotUnique` past validations.

⚠️ **Before deploying:** check production for duplicate `advocate_users.student_number` rows — `SELECT student_number, COUNT(*) FROM advocate_users GROUP BY 1 HAVING COUNT(*) > 1;`

Base: `test-infrastructure` (#63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)