### PR TITLE
Use deliver_now in mailer calls

### DIFF
--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -45,6 +45,6 @@ class AdminUser < ActiveRecord::Base
   private
 
   def send_password
-    RegistrationMailer.welcome_secretary(email, password).deliver
+    RegistrationMailer.welcome_secretary(email, password).deliver_now
   end
 end

--- a/app/models/advocate_user.rb
+++ b/app/models/advocate_user.rb
@@ -32,6 +32,6 @@ class AdvocateUser < ActiveRecord::Base
   protected
 
   def send_welcome_email
-    RegistrationMailer.welcome_advocate(email).deliver
+    RegistrationMailer.welcome_advocate(email).deliver_now
   end
 end

--- a/spec/models/welcome_email_spec.rb
+++ b/spec/models/welcome_email_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe "Welcome emails" do
+  it "are sent when an admin user is created" do
+    expect {
+      create(:admin_user)
+    }.to change { ActionMailer::Base.deliveries.count }.by(1)
+  end
+
+  it "are sent when an advocate user is created" do
+    expect {
+      create(:advocate_user)
+    }.to change { ActionMailer::Base.deliveries.count }.by(1)
+  end
+end


### PR DESCRIPTION
Plan item **3.4** (minimal fix only, per review decision).

`RegistrationMailer...deliver` works only via Delegator fallthrough to `Mail::Message#deliver`, bypassing ActionMailer instrumentation — fragile across upgrades. Now `.deliver_now`.

Explicitly **not** moving `after_create` → `after_commit`: a mail failure visibly failing the creation is acceptable (the admin notices immediately).

Specs: creating an admin user / advocate user delivers exactly one welcome email.

Base: `test-infrastructure` (#63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)