### PR TITLE
Phase 5: authorization matrix and happy-path request specs

### DIFF
--- a/spec/models/email_pipeline_spec.rb
+++ b/spec/models/email_pipeline_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+# The delayed_job stack (YAML serialization of AR objects on psych 4 +
+# aws-actionmailer-ses) has churned recently: prove that an enqueued Email
+# deserializes and performs against the test mailer. A manual run against
+# the SES sandbox in QA is still part of the pre-election checklist.
+describe "Email pipeline" do
+  it "delivers enqueued candidate emails through delayed_job" do
+    create_list(:candidate, 2)
+    email = Email.create!(subject: "Tiedote", content: "Sisältö")
+
+    expect { email.enqueue! }.to change { Delayed::Job.count }.by(1)
+
+    # Performing the fan-out job enqueues one mailer job per candidate.
+    fan_out = Delayed::Job.last
+    fan_out.invoke_job
+
+    mailer_jobs = Delayed::Job.where.not(id: fan_out.id)
+    expect(mailer_jobs.count).to eq 2
+
+    expect {
+      mailer_jobs.each(&:invoke_job)
+    }.to change { ActionMailer::Base.deliveries.count }.by(2)
+
+    delivered = ActionMailer::Base.deliveries.last(2)
+    expect(delivered.map(&:subject)).to all(eq "Tiedote")
+  end
+end

--- a/spec/models/fake_auth_spec.rb
+++ b/spec/models/fake_auth_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Vaalit::Config do
+  describe ".fake_auth_enabled?" do
+    it "is enabled in the test env (development stage + flag)" do
+      expect(Vaalit::Config.fake_auth_enabled?).to eq true
+    end
+
+    it "is disabled when STAGE=production even with FAKE_AUTH_ENABLED=yes" do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("STAGE", nil).and_return("production")
+      allow(ENV).to receive(:fetch).with("FAKE_AUTH_ENABLED", "no").and_return("yes")
+
+      expect(Vaalit::Config.fake_auth_enabled?).to eq false
+    end
+  end
+end

--- a/spec/requests/authorization_matrix_spec.rb
+++ b/spec/requests/authorization_matrix_spec.rb
@@ -1,0 +1,123 @@
+require 'spec_helper'
+
+# Authorization boundaries per role. The manage-page and admin boundaries
+# are covered in spec/requests/manage_pages_spec.rb, team alliance access
+# in spec/requests/advocates_alliances_spec.rb.
+describe "Authorization boundaries" do
+  describe "guest" do
+    it "gets 401 from registration pages" do
+      get registrations_root_path
+      expect(response).to have_http_status(:unauthorized)
+
+      get registrations_candidate_path
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "is redirected away from advocate pages" do
+      get advocates_alliances_path
+      expect(response).to redirect_to(registrations_root_path)
+    end
+  end
+
+  describe "Haka user without advocate rights" do
+    before { sign_in_haka "012345678" }
+
+    it "is redirected away from advocate pages" do
+      get advocates_alliances_path
+      expect(response).to redirect_to(registrations_root_path)
+    end
+  end
+
+  describe "Haka user outside the nomination period" do
+    let(:student_number) { "012345678" }
+
+    before { sign_in_haka student_number }
+
+    it "cannot register as a candidate during the correction period" do
+      allow(GlobalConfiguration).to receive(:candidate_nomination_period_effective?).and_return(false)
+      allow(GlobalConfiguration).to receive(:candidate_data_correction_period?).and_return(true)
+      allow(GlobalConfiguration).to receive(:candidate_data_frozen?).and_return(false)
+
+      get new_registrations_candidate_path, params: { invite_code: "ABCD" }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "can still update but not create during the correction period" do
+      candidate = create(:candidate, student_number: student_number)
+
+      allow(GlobalConfiguration).to receive(:candidate_nomination_period_effective?).and_return(false)
+      allow(GlobalConfiguration).to receive(:candidate_data_correction_period?).and_return(true)
+      allow(GlobalConfiguration).to receive(:candidate_data_frozen?).and_return(false)
+      allow(GlobalConfiguration).to receive(:log_candidate_attribute_changes?).and_return(false)
+
+      patch registrations_candidate_path, params: { candidate: { phone_number: "040111" } }
+
+      expect(response).to redirect_to(registrations_candidate_path)
+      expect(candidate.reload.phone_number).to eq "040111"
+    end
+
+    it "cannot update or cancel when candidate data is frozen" do
+      candidate = create(:candidate, student_number: student_number, phone_number: "unchanged")
+
+      allow(GlobalConfiguration).to receive(:candidate_nomination_period_effective?).and_return(false)
+      allow(GlobalConfiguration).to receive(:candidate_data_correction_period?).and_return(false)
+      allow(GlobalConfiguration).to receive(:candidate_data_frozen?).and_return(true)
+
+      patch registrations_candidate_path, params: { candidate: { phone_number: "040999" } }
+      expect(response).to have_http_status(:forbidden)
+
+      post cancel_registrations_candidate_path
+      expect(response).to have_http_status(:forbidden)
+
+      expect(candidate.reload.phone_number).to eq "unchanged"
+      expect(candidate.cancelled).to eq false
+    end
+  end
+
+  describe "advocate when advocate login is disabled" do
+    it "is denied" do
+      create(:global_configuration, advocate_login_enabled: false)
+      advocate = create(:advocate_user)
+      sign_in_haka advocate.student_number
+
+      get advocates_alliances_path
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe "advocate and a foreign alliance's candidates" do
+    let(:advocate) { create(:advocate_user) }
+    let(:foreign_alliance) { create(:electoral_alliance) }
+
+    before do
+      create(:global_configuration)
+      sign_in_haka advocate.student_number
+    end
+
+    it "cannot create a candidate into a foreign alliance" do
+      expect {
+        post advocates_alliance_candidates_path(foreign_alliance), params: {
+          candidate: {
+            lastname: "Vieras", firstname: "Ville",
+            candidate_name: "Vieras, Ville",
+            email: "ville@example.com", student_number: "999888"
+          }
+        }
+      }.not_to change { Candidate.count }
+
+      expect(response).to have_http_status(:redirect)
+    end
+
+    it "cannot update a foreign alliance's candidate" do
+      candidate = create(:candidate, electoral_alliance: foreign_alliance, phone_number: "unchanged")
+
+      patch advocates_alliance_candidate_path(foreign_alliance, candidate),
+        params: { candidate: { phone_number: "040999" } }
+
+      expect(response).to have_http_status(:redirect)
+      expect(candidate.reload.phone_number).to eq "unchanged"
+    end
+  end
+end

--- a/spec/requests/happy_paths_spec.rb
+++ b/spec/requests/happy_paths_spec.rb
@@ -1,0 +1,106 @@
+require 'spec_helper'
+
+describe "Happy paths" do
+  describe "candidate registration flow" do
+    it "shows the form with a valid invite code" do
+      alliance = create(:electoral_alliance, invite_code: "KOODI")
+      sign_in_haka "012345678"
+
+      get new_registrations_candidate_path, params: { invite_code: "koodi" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(alliance.name)
+    end
+  end
+
+  describe "advocate alliance and candidate management" do
+    let(:advocate) { create(:advocate_user) }
+
+    before do
+      create(:global_configuration)
+      sign_in_haka advocate.student_number
+    end
+
+    it "creates an alliance owned by the advocate" do
+      post advocates_alliances_path, params: {
+        electoral_alliance: {
+          name: "Uusi vaaliliitto",
+          shorten: "UUSI",
+          expected_candidate_count: 5,
+          invite_code: "UU-12"
+        }
+      }
+
+      alliance = ElectoralAlliance.find_by(name: "Uusi vaaliliitto")
+      expect(alliance).to be_present
+      expect(alliance.advocate_user).to eq advocate
+      expect(response).to redirect_to(advocates_alliance_path(alliance))
+    end
+
+    # Note: the ability grants :create, Candidate only for one's own student
+    # number — candidates register themselves; advocates edit, not create.
+    it "edits a candidate in the advocate's own alliance" do
+      alliance = create(:electoral_alliance, advocate_user: advocate)
+      candidate = create(:candidate, electoral_alliance: alliance)
+
+      patch advocates_alliance_candidate_path(alliance, candidate),
+        params: { candidate: { phone_number: "040 123" } }
+
+      expect(response).to redirect_to(advocates_alliance_path(alliance))
+      expect(candidate.reload.phone_number).to eq "040 123"
+    end
+  end
+
+  describe "admin CSV exports" do
+    before do
+      coalition = create(:electoral_coalition)
+      alliance = create(:electoral_alliance, electoral_coalition: coalition)
+      create_list(:candidate, 3, electoral_alliance: alliance)
+      sign_in create(:admin_user)
+    end
+
+    def parse_csv(body, encoding)
+      CSV.parse(body.dup.force_encoding(encoding).encode("UTF-8"))
+    end
+
+    it "exports candidates, alliances and coalitions in both encodings" do
+      {
+        manage_candidates_path(format: :csv) => 4, # header + 3 candidates
+        reduced_manage_candidates_path(format: :csv) => 4,
+        manage_electoral_alliances_path(format: :csv) => 2,
+        manage_electoral_coalitions_path(format: :csv) => 2
+      }.each do |path, expected_rows|
+        get path
+        expect(response).to have_http_status(:ok)
+        rows = parse_csv(response.body, "UTF-8")
+        expect(rows.length).to eq(expected_rows), "#{path}: expected #{expected_rows} rows, got #{rows.length}"
+      end
+
+      [
+        manage_candidates_path(format: :csv, isolatin: true),
+        manage_electoral_alliances_path(format: :csv, isolatin: true),
+        manage_electoral_coalitions_path(format: :csv, isolatin: true)
+      ].each do |path|
+        get path
+        expect(response).to have_http_status(:ok)
+        expect { parse_csv(response.body, "ISO-8859-1") }.not_to raise_error
+      end
+    end
+  end
+
+  describe "candidate numbering end to end" do
+    it "assigns numbers through the danger zone" do
+      coalition = create(:electoral_coalition)
+      2.times do
+        alliance = create(:electoral_alliance, electoral_coalition: coalition)
+        create_list(:candidate, 2, electoral_alliance: alliance)
+      end
+      sign_in create(:admin_user)
+
+      post give_candidate_numbers_manage_danger_zone_path
+
+      expect(response).to redirect_to(manage_candidates_path)
+      expect(Candidate.valid.pluck(:candidate_number).sort).to eq [2, 3, 4, 5]
+    end
+  end
+end


### PR DESCRIPTION
Plan **Phase 5**, tracks 2 and 3 (track 1's per-fix regression specs shipped inside each fix PR).

**Authorization request specs** (the boundaries are the product):
- guest: registrations → 401, advocates → redirect (manage-page boundary already pinned in #67)
- Haka user: update allowed but create denied in the correction period; update/cancel denied when data is frozen
- advocate: denied when `advocate_login_enabled` is off; cannot create/update a foreign alliance's candidates (team read-only boundary already pinned in #68)
- `Vaalit::Config.fake_auth_enabled?` is false when `STAGE=production` even with `FAKE_AUTH_ENABLED=yes`

**Happy paths:**
- registration form renders with a valid invite code (create+show flow pinned in #71)
- advocate creates an alliance; edits a candidate in their own alliance. *Finding while writing these: advocates cannot create candidates at all — the ability grants `:create, Candidate` only for one's own student number. That matches the post-2022 self-registration flow, so the spec pins editing.*
- all seven dashboard CSV export links (candidates / reduced / alliances / coalitions, UTF-8 + ISO-Latin) return parseable CSV with the right row counts
- candidate numbering end-to-end through the danger zone (numbers 2..N, plan convention)

**Email pipeline:** `Email#enqueue!` → `Delayed::Job` row → deserializes → fan-out job enqueues one mailer job per candidate → mailer jobs deliver against test-deliveries. This backs the manual pre-election SES-sandbox checklist item.

Suite on this branch: 23 examples, 0 failures.

Base: `test-infrastructure` (#63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)