### PR TITLE
fix: Remove dead alliance-missing branches from admin candidate form

### DIFF
--- a/app/admin/candidates.rb
+++ b/app/admin/candidates.rb
@@ -24,7 +24,8 @@ ActiveAdmin.register Candidate do
   scope "Voimassa", :valid
 
   controller do
-    # Override default method because :electoral_alliance_ids is not available in permitted_params.
+    # Override the default update to redirect to the alliance page instead of
+    # the candidate page.
     def update
       @candidate = Candidate.find(params[:id])
 
@@ -39,8 +40,9 @@ ActiveAdmin.register Candidate do
       end
     end
 
+    # Override the default create to redirect to the alliance page instead of
+    # the candidate page.
     def create
-      # Override default method because :electoral_alliance_ids is not available in permitted_params.
       @candidate = Candidate.new(permitted_params[:candidate])
       alliance_id = params[:candidate][:electoral_alliance_id]
 
@@ -106,13 +108,9 @@ ActiveAdmin.register Candidate do
         para "Luo ehdokas menemällä vaaliliiton sivulle ja klikkaa sieltä 'Uusi ehdokas'."
       end
     else
-      # Candidate#electoral_alliance_id can be nil if candidate was in an
-      # alliance, but alliance was deleted.
-      alliance = ElectoralAlliance.find_by_id(alliance_id)
+      alliance = ElectoralAlliance.find(alliance_id)
 
-      alliance_name = alliance.present? ? alliance.name : "Vaaliliitto puuttuu"
-
-      f.inputs "Ehdokkaan vaaliliitto: #{alliance_name}" do
+      f.inputs "Ehdokkaan vaaliliitto: #{alliance.name}" do
         f.input :lastname
         f.input :firstname
         f.input :candidate_name
@@ -140,18 +138,9 @@ ActiveAdmin.register Candidate do
       end
 
       # Prevent potential errors by not allowing to change the alliance.
-      # Allow to set alliance only for previously saved candidates who do not
-      # have an alliance (ie. alliance was deleted after candidate was created).
-      # => Do not display alliance dropdown on NEW or EDIT actions.
-      if alliance.present? || f.object.new_record?
-        f.input :electoral_alliance_id,
-                :as => :hidden,
-                :input_html => {:value => alliance.id}
-      else
-        f.inputs 'Vaaliliitto' do
-          f.input :electoral_alliance
-        end
-      end
+      f.input :electoral_alliance_id,
+              :as => :hidden,
+              :input_html => {:value => alliance.id}
 
       f.actions
     end

--- a/spec/requests/happy_paths_spec.rb
+++ b/spec/requests/happy_paths_spec.rb
@@ -13,6 +13,18 @@ describe "Happy paths" do
     end
   end
 
+  describe "admin candidate management" do
+    it "renders the candidate edit form" do
+      candidate = create(:candidate)
+      sign_in create(:admin_user)
+
+      get edit_admin_candidate_path(candidate)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(candidate.electoral_alliance.name)
+    end
+  end
+
   describe "advocate alliance and candidate management" do
     let(:advocate) { create(:advocate_user) }
 


### PR DESCRIPTION
Plan item 3 of `plans/2026-07-10-post-review-followups.md` — delete-only plus comment fixes, no behavior change:

- The form's "alliance was deleted" branches are provably dead since `candidates.electoral_alliance_id` became NOT NULL and an alliance with candidates cannot be destroyed (`dependent: :restrict_with_error`). Removed the `find_by_id` + "Vaaliliitto puuttuu" fallback and the `else` branch rendering an alliance dropdown; the hidden `electoral_alliance_id` field is now always rendered.
- The `params[:action] == "new" && alliance_id.nil?` guard at the top of the form stays — it is the real entry path for "create candidate without picking an alliance first".
- Rewrote the stale `create`/`update` override comments: the overrides exist to redirect to the alliance page instead of the candidate page, not because of `permitted_params`.
- Added a happy-path request spec rendering the admin candidate edit form (there was none).

Suite green: 77 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)