### PR TITLE
fix: Make GlobalConfiguration a real singleton

### DIFF
--- a/app/controllers/manage/configurations_controller.rb
+++ b/app/controllers/manage/configurations_controller.rb
@@ -2,18 +2,18 @@ class Manage::ConfigurationsController < ManageController
   before_action :find_configuration
 
   def enable_advocate_login
-    GlobalConfiguration.first.enable_advocate_login!
+    GlobalConfiguration.instance.enable_advocate_login!
     redirect_to manage_danger_zone_path
   end
 
   def disable_advocate_login
-    GlobalConfiguration.first.disable_advocate_login!
+    GlobalConfiguration.instance.disable_advocate_login!
     redirect_to manage_danger_zone_path
   end
 
   protected
 
   def find_configuration
-    @configuration = GlobalConfiguration.first
+    @configuration = GlobalConfiguration.instance
   end
 end

--- a/app/controllers/manage/danger_zones_controller.rb
+++ b/app/controllers/manage/danger_zones_controller.rb
@@ -1,6 +1,6 @@
 class Manage::DangerZonesController < ManageController
   def show
-    @configuration = GlobalConfiguration.first
+    @configuration = GlobalConfiguration.instance
   end
 
   def give_candidate_numbers

--- a/app/models/global_configuration.rb
+++ b/app/models/global_configuration.rb
@@ -42,8 +42,14 @@ class GlobalConfiguration < ActiveRecord::Base
     not candidate_nomination_period_effective?
   end
 
+  # The single configuration row, created on demand. Auto-creating is safe:
+  # the only column, advocate_login_enabled, defaults to false.
+  def self.instance
+    first_or_create!
+  end
+
   def self.advocate_login_enabled?
-    !!first&.advocate_login_enabled?
+    instance.advocate_login_enabled?
   end
 
   def enable_advocate_login!

--- a/spec/models/nil_guards_spec.rb
+++ b/spec/models/nil_guards_spec.rb
@@ -35,9 +35,13 @@ describe "Nil guards" do
   end
 
   describe GlobalConfiguration do
-    it "advocate_login_enabled? is false when the table is empty" do
+    it "instance creates the row and advocate_login_enabled? is false on an empty table" do
       expect(GlobalConfiguration.count).to eq 0
+
       expect(GlobalConfiguration.advocate_login_enabled?).to eq false
+
+      expect(GlobalConfiguration.count).to eq 1
+      expect(GlobalConfiguration.instance).to eq GlobalConfiguration.first
     end
   end
 end


### PR DESCRIPTION
Plan item 4 of `plans/2026-07-10-post-review-followups.md`:

`GlobalConfiguration.first` crashed with `NoMethodError` on an empty table in `Manage::ConfigurationsController#enable_advocate_login` / `#disable_advocate_login` / `#find_configuration` and `Manage::DangerZonesController#show`. The 2026-07-07 remediation (2.7) only nil-guarded the `advocate_login_enabled?` reader.

Root-cause fix in one place: `GlobalConfiguration.instance` defined as `first_or_create!`, used in the four call sites and the reader. Auto-creating the row is safe — the only column, `advocate_login_enabled`, defaults to `false`.

The existing nil-guard model spec now also asserts that `instance` creates the row on an empty table.

Suite green: 76 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)